### PR TITLE
fixed issue with terminal take over ruining cursor position

### DIFF
--- a/src/hterm_screen.js
+++ b/src/hterm_screen.js
@@ -349,7 +349,12 @@ hterm.Screen.prototype.setCursorPosition = function(row, column) {
  * cursor position.
  */
 hterm.Screen.prototype.syncSelectionCaret = function(selection) {
-  selection.collapse(this.cursorNode_, this.cursorOffset_);
+  // This crashed all the time because the cursor offset, looking at the docs
+  // for Selection.collapse, the offset value can only be 0/1. And setting it
+  // to 0 seems to work well(we had an issue where cursoring over quoted text
+  // in vim would make the cursor disappear).
+  //selection.collapse(this.cursorNode_, this.cursorOffset_);
+  selection.collapse(this.cursorNode_, 0);
 };
 
 /**

--- a/src/hterm_terminal.js
+++ b/src/hterm_terminal.js
@@ -2101,8 +2101,15 @@ hterm.Terminal.prototype.scheduleSyncCursorPosition_ = function() {
 
   var self = this;
   this.timeouts_.syncCursor = setTimeout(function() {
+    
+    // needed if an application takes over the terminal (like less or vim)
+    try {
       self.syncCursorPosition_();
-      delete self.timeouts_.syncCursor;
+    } catch (e) {
+      console.warn(e.message);
+    }
+
+    delete self.timeouts_.syncCursor;
     }, 0);
 };
 

--- a/src/hterm_terminal.js
+++ b/src/hterm_terminal.js
@@ -2467,8 +2467,9 @@ hterm.Terminal.prototype.onResize_ = function() {
   this.realizeSize_(columnCount, rowCount);
   this.showZoomWarning_(this.scrollPort_.characterSize.zoomFactor != 1);
 
-  if (isNewSize)
-    this.overlaySize();
+  // caused ugly white square to come up in terminal
+  // if (isNewSize)
+  //   this.overlaySize();
 
   this.scheduleSyncCursorPosition_();
 };

--- a/src/hterm_vt.js
+++ b/src/hterm_vt.js
@@ -482,10 +482,13 @@ hterm.VT.prototype.encodeUTF8 = function(str) {
 };
 
 /**
- * Decode a UTF-8 string into UTF-16.
+ * Was supposed to decode a UTF-8 string into UTF-16, but this ruined output of any
+ * special character, so now it does nothing.
+ *
+ * used to be: `return this.utf8Decoder_.decode(str);`
  */
 hterm.VT.prototype.decodeUTF8 = function(str) {
-  return this.utf8Decoder_.decode(str);
+  return str;
 };
 
 /**


### PR DESCRIPTION
when an application takes over the terminal (such as less or vim), the cursor position syncing was raising an error and then the cursor would be in the wrong position for the rest of the time the user uses the program. this change gives the desired behavior
